### PR TITLE
1.0.1

### DIFF
--- a/src/main/java/it/mitl/healthSync/HealthSync.java
+++ b/src/main/java/it/mitl/healthSync/HealthSync.java
@@ -1,5 +1,6 @@
 package it.mitl.healthSync;
 
+import it.mitl.healthSync.Listeners.Syncing;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HealthSync extends JavaPlugin {
@@ -7,7 +8,7 @@ public final class HealthSync extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
-
+        this.getServer().getPluginManager().registerEvents(new Syncing(this), this);
     }
 
     @Override

--- a/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
+++ b/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
@@ -1,4 +1,4 @@
-package it.mitl.healthSync;
+package it.mitl.healthSync.Listeners;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -11,60 +11,73 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class Sync implements Listener {
+public class Syncing implements Listener {
 
     private final JavaPlugin plugin;
-    private boolean isSyncing = false;
+    private boolean isDeathSyncing = false;
 
-    public Sync(JavaPlugin plugin) {
+    public Syncing(JavaPlugin plugin) {
         this.plugin = plugin;
     }
 
     @EventHandler
     public void onEntityDamageEvent(EntityDamageEvent event) {
         // Handle the event
-        if (event.getEntity() instanceof Player) { // Check if the entity is a player
+        if (event.getEntity() instanceof Player eventPlayer) { // Check if the entity is a player
             double damage = event.getDamage(); // Set a variable to the damage
+            if (eventPlayer.getHealth() - damage <= 0) return; // Check if the player will die
             for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
-                if (!player.equals(event.getEntity())) { // Exclude the player who triggered the event
+                if (!player.equals(eventPlayer)) { // Exclude the player who triggered the event
                     player.setHealth(player.getHealth() - damage); // Set the player's health to the current health minus the damage
                 }
             }
         }
-        event.setCancelled(true); // Cancel the event
     }
 
     @EventHandler
     public void onEntityRegainHealthEvent(EntityRegainHealthEvent event) {
         // Handle the event
-        if (event.getEntity() instanceof Player) { // Check if the entity is a player
+        if (event.getEntity() instanceof Player eventPlayer) { // Check if the entity is a player
             double health = event.getAmount(); // Set a variable to the health
             for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
-                player.setHealth(player.getHealth() + health); // Set the player's health to the current health plus the health
+                if (!player.equals(eventPlayer)) { // Exclude the player who triggered the event
+                    player.setHealth(player.getHealth() + health); // Set the player's health to the current health plus the health
+                }
             }
         }
-        event.setCancelled(true); // Cancel the event
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         // Handle the event
-        // Pick a random online player and set the new player's health to that player's health
-        Player player = Bukkit.getOnlinePlayers().stream().findAny().orElse(null);
-        event.getPlayer().setHealth(player.getHealth());
+        if (Bukkit.getOnlinePlayers().size() <= 1) {
+            // If the server is empty or only the joining player is online, do nothing
+            return;
+        }
+
+        // Pick a random online player that is not the joining player
+        Player joiningPlayer = event.getPlayer();
+        Bukkit.getOnlinePlayers().stream()
+                .filter(player -> !player.equals(joiningPlayer))
+                .findAny().ifPresent(randomPlayer -> joiningPlayer.setHealth(randomPlayer.getHealth()));
+
     }
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         // Handle the event
-        if (isSyncing) return; // Check if the player is already dead
-        isSyncing = true;
+        if (isDeathSyncing) return; // Check if a player is already dead
+        isDeathSyncing = true;
+        String deathMessage = event.getDeathMessage();
+        if (deathMessage != null) {
+            plugin.getServer().broadcastMessage(ChatColor.RED + deathMessage);
+        }
         for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
+            if (player.equals(event.getEntity())) continue; // Skip the player who died
             player.setHealth(0); // Set the player's health to 0
         }
-        isSyncing = false;
-        // Send a message to all players stating who died
-        plugin.getServer().broadcastMessage(ChatColor.RED + "Whoops! Looks like " + event.getEntity().getName() + " died!");
+        event.setDeathMessage(null); // Set the death message to null to prevent the default death message from being displayed
+        isDeathSyncing = false; // Reset the death syncing flag
     }
 
 }

--- a/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
+++ b/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
@@ -15,6 +15,7 @@ public class Syncing implements Listener {
 
     private final JavaPlugin plugin;
     private boolean isDeathSyncing = false;
+    private String deathGuiltyPlayer = "";
 
     public Syncing(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -24,6 +25,7 @@ public class Syncing implements Listener {
     public void onEntityDamageEvent(EntityDamageEvent event) {
         // Handle the event
         if (event.getEntity() instanceof Player eventPlayer) { // Check if the entity is a player
+            if (eventPlayer.isDead()) return; // Ignore the event if the player is dead
             double damage = event.getDamage(); // Set a variable to the damage
             if (eventPlayer.getHealth() - damage <= 0) return; // Check if the player will die
             for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
@@ -38,6 +40,7 @@ public class Syncing implements Listener {
     public void onEntityRegainHealthEvent(EntityRegainHealthEvent event) {
         // Handle the event
         if (event.getEntity() instanceof Player eventPlayer) { // Check if the entity is a player
+            if (eventPlayer.isDead()) return; // Ignore the event if the player is dead
             double health = event.getAmount(); // Set a variable to the health
             for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
                 if (!player.equals(eventPlayer)) { // Exclude the player who triggered the event
@@ -64,8 +67,13 @@ public class Syncing implements Listener {
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         // Handle the event
-        if (isDeathSyncing) return; // Check if a player is already dead
+        if (isDeathSyncing) {
+            // Check if a player is already dead
+            event.setDeathMessage(event.getEntity().getPlayer().getName() + " died because of " + deathGuiltyPlayer); // Change the death message to mention the player who caused the death.
+            return; // Return in order not to cause a death loop.
+        }
         isDeathSyncing = true; // Set the death syncing flag to true
+        deathGuiltyPlayer = event.getEntity().getPlayer().getName(); // Set the death guilty player
         String deathMessage = event.getDeathMessage(); // Create a variable to store the death message
         if (deathMessage != null) { // Check if the death message is not null
             plugin.getServer().broadcastMessage(ChatColor.RED + deathMessage); // Broadcast the death message in red

--- a/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
+++ b/src/main/java/it/mitl/healthSync/Listeners/Syncing.java
@@ -50,16 +50,14 @@ public class Syncing implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         // Handle the event
-        if (Bukkit.getOnlinePlayers().size() <= 1) {
-            // If the server is empty or only the joining player is online, do nothing
-            return;
+        if (Bukkit.getOnlinePlayers().size() <= 1) { // Check if the server is empty
+            return; // Return if the server is empty
         }
 
-        // Pick a random online player that is not the joining player
-        Player joiningPlayer = event.getPlayer();
-        Bukkit.getOnlinePlayers().stream()
-                .filter(player -> !player.equals(joiningPlayer))
-                .findAny().ifPresent(randomPlayer -> joiningPlayer.setHealth(randomPlayer.getHealth()));
+        Player joiningPlayer = event.getPlayer(); // Create a variable to store the joining player
+        Bukkit.getOnlinePlayers().stream() // Get a stream of online players
+                .filter(player -> !player.equals(joiningPlayer)) // Exclude the joining player
+                .findAny().ifPresent(randomPlayer -> joiningPlayer.setHealth(randomPlayer.getHealth())); // Set the joining player's health to the random player's health
 
     }
 
@@ -67,10 +65,10 @@ public class Syncing implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         // Handle the event
         if (isDeathSyncing) return; // Check if a player is already dead
-        isDeathSyncing = true;
-        String deathMessage = event.getDeathMessage();
-        if (deathMessage != null) {
-            plugin.getServer().broadcastMessage(ChatColor.RED + deathMessage);
+        isDeathSyncing = true; // Set the death syncing flag to true
+        String deathMessage = event.getDeathMessage(); // Create a variable to store the death message
+        if (deathMessage != null) { // Check if the death message is not null
+            plugin.getServer().broadcastMessage(ChatColor.RED + deathMessage); // Broadcast the death message in red
         }
         for (Player player : Bukkit.getOnlinePlayers()) { // Loop through all online players
             if (player.equals(event.getEntity())) continue; // Skip the player who died


### PR DESCRIPTION
# HealthSync 1.0.1

## Changelog:

- Fixed errors involving health values going into negatives due to bad death handling in the EntityDamageEvent.
- Fixed problems to do with death message order.
- Replaced the non-specific (generic) death announcement with the player's actual death message.
- Added additional comments for a better explanation
- Added the guilty player to the death messages of other players
- Now ignores the events related to health syncing if a player is already dead in order to prevent errors.

