### PR TITLE
[1.0.2] - 2025-02-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+
+# HealthSync - Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.0.2] - 2025-02-26
+
+List of changes for the 1.0.2 release.
+
+### Added
+- **Relative Damage**: Added a new feature to calculate relative damage.
+  - **Relative Damage Rounding**: Rounds relative damage to the nearest whole number.
+- **Damage Effect**: Added a new feature to display the usual damage effect.
+- **Changelog**: Added a changelog file to keep track of changes.
+- **bStats**: Added bStats to track plugin usage statistics.
+
+### Fixed
+- **Health Surplus**: Fixed a bug where the plugin would attempt to increase player health above **20 points** and cause an error output in console. 
+
+## [1.0.1] - 2025-02-01
+
+List of changes for the 1.0.1 release.
+
+### Added
+- **Additional Comments**: Added additional comments for a better explanation.
+- **Death Shaming**: Added the guilty player to the death messages of other players
+
+### Changed
+
+- **Better Death Announcements**: Replaced the non-specific (generic) death announcement with the player's actual death message.
+
+### Fixed
+
+- **Negative Health**: Fixed errors involving health values going into negatives due to bad death handling in the EntityDamageEvent.
+- **Death Message Order**: Fixed problems to do with death message order.
+
+## [1.0.0] - 2025-01-26
+
+List of changes for the 1.0.0 release.
+
+### Added
+- **Initial Release**: Added the initial plugin release.
+
+*based on [juampynr's changelog example](https://gist.github.com/juampynr/4c18214a8eb554084e21d6e288a18a2c)*

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>it.mitl</groupId>
     <artifactId>HealthSync</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>HealthSync</name>
@@ -38,6 +38,15 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.bstats</pattern>
+                                    <!-- Replace this with your package! -->
+                                    <shadedPattern>it.mitl.healthSync</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -67,6 +76,12 @@
             <artifactId>spigot-api</artifactId>
             <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/it/mitl/healthSync/HealthSync.java
+++ b/src/main/java/it/mitl/healthSync/HealthSync.java
@@ -1,6 +1,8 @@
 package it.mitl.healthSync;
 
 import it.mitl.healthSync.Listeners.Syncing;
+import org.bstats.bukkit.Metrics;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HealthSync extends JavaPlugin {
@@ -8,6 +10,15 @@ public final class HealthSync extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
+
+        // Configuration Setup
+        saveDefaultConfig();
+        FileConfiguration config = getConfig();
+
+        // bStats
+        int pluginId = 24929;
+        Metrics metrics = new Metrics(this, pluginId);
+
         this.getServer().getPluginManager().registerEvents(new Syncing(this), this);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,5 @@
+# HealthSync Configuration
+
+
+# Relative Damage - Splits damage amongst all online players. E.g. 2 players with 5 damage = 2.5 damage each.
+relative_damage: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HealthSync
-version: '1.0.1'
+version: '1.0.2'
 main: it.mitl.healthSync.HealthSync
 api-version: '1.21'
 authors: [ Mitlit ]


### PR DESCRIPTION
List of changes for the 1.0.2 release.

### Added
- **Relative Damage**: Added a new feature to calculate relative damage.
  - **Relative Damage Rounding**: Rounds relative damage to the nearest whole number.
- **Damage Effect**: Added a new feature to display the usual damage effect.
- **Changelog**: Added a changelog file to keep track of changes.
- **bStats**: Added bStats to track plugin usage statistics.

### Fixed
- **Health Surplus**: Fixed a bug where the plugin would attempt to increase player health above **20 points** and cause an error output in console.